### PR TITLE
Support new branches when showing need for push/pull.

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -16,13 +16,39 @@ module.exports = function(working_directory) {
     var branchResult = runSync('git', ["symbolic-ref", "HEAD"], srcpath, console, true);
     var branch = branchResult.stdout.toString().replace("refs/heads/", "").trim();
 
+    var availableBranches = runSync(`git`, ["branch", "-a"], srcpath, console, true);
+    availableBranches = availableBranches.stdout.toString().split("\n");
+
     var trackedChanges = runSync('git', ["diff-index", "HEAD"], srcpath, console, true);
     var untrackedChanges = runSync('git', ["ls-files", "--other", "--exclude-standard", "--directory"], srcpath, console, true)
-    var aheadOrBehind = runSync('git', ["rev-list", "--left-right", "--count", branch + "...origin/" + branch], srcpath, console, true);
 
-    var differences = aheadOrBehind.stdout.toString().trim().split("\t").map(function(str) {
-      return parseInt(str);
-    });
+    var remoteBranchIsAvailable = false;
+    var localAhead = 0;
+    var remoteAhead = 0;
+
+    var expectedRemote = "remotes/origin/" + branch;
+
+    for (var i = 0; i < availableBranches.length; i++) {
+      var currentBranch = availableBranches[i];
+      if (currentBranch.indexOf(expectedRemote) >= 0) {
+        remoteBranchIsAvailable = true;
+        break;
+      }
+    }
+
+    if (remoteBranchIsAvailable) {
+      var aheadOrBehind = runSync('git', ["rev-list", "--left-right", "--count", branch + "...origin/" + branch], srcpath, console, true);
+
+      var differences = aheadOrBehind.stdout.toString().trim().split("\t").map(function(str) {
+        return parseInt(str);
+      });
+
+      localAhead = differences[0];
+      remoteAhead = differences[1];
+    } else {
+      // If the remote branch isn't available, then we definitely require a push.
+      localAhead = 1;
+    }
 
     // TODO: I could probably simplify this expression.
     var totalChanges =
@@ -35,8 +61,8 @@ module.exports = function(working_directory) {
       package: directory,
       branch: branch,
       localChanges: hasLocalChanges,
-      needsPush: differences[0] > 0,
-      needsPull: differences[1] > 0
+      needsPush: localAhead > 0,
+      needsPull: remoteAhead > 0
     });
   });
 


### PR DESCRIPTION
This prevents a git command from erroring when checking to see if a branch is ahead or behind.